### PR TITLE
fix allow rotten corpses

### DIFF
--- a/1.4/Defs/RecipeDefs/Recipes_Harvest.xml
+++ b/1.4/Defs/RecipeDefs/Recipes_Harvest.xml
@@ -59,7 +59,6 @@
         <li>R3_AllowHarvested</li>
         <li>R3_AllowUnharvested_Advanced</li>
         <li>R3_AllowUnharvested_Glittertech</li>
-        <li>AllowRotten</li>
       </specialFiltersToDisallow>
     </fixedIngredientFilter>
   </RecipeDef>
@@ -79,7 +78,6 @@
       <specialFiltersToDisallow>
         <li>R3_AllowHarvested</li>
         <li>R3_AllowUnharvested_Glittertech</li>
-        <li>AllowRotten</li>
       </specialFiltersToDisallow>
     </fixedIngredientFilter>
   </RecipeDef>
@@ -98,7 +96,6 @@
       </disallowedCategories>
       <specialFiltersToDisallow>
         <li>R3_AllowHarvested</li>
-        <li>AllowRotten</li>
       </specialFiltersToDisallow>
     </fixedIngredientFilter>
   </RecipeDef>


### PR DESCRIPTION
It is currently not possible to harvest from rotten corpses. I'm not a C# programmer or a modder so I can't explain why this fixes it.

I tried adding `AllowFresh` as a filter alongside `AllowRotten` but it removed both options from the game menu. Removing both options from the xml makes them both appear in the game menu.

It seems like this issue existed before 1.4 based on the steam comments but I didn't want to touch the other builds because I don't want to test them.